### PR TITLE
Convert posetsolver methods to static

### DIFF
--- a/backend/app/classes.py
+++ b/backend/app/classes.py
@@ -1,13 +1,13 @@
 import networkx as nx
 
-PartialOrder = list[tuple[int, int]]
-CoverRelation = list[tuple[int, int]]
-LinearOrder = str
-AcyclicDiGraph = nx.DiGraph
-HasseDiagram = nx.DiGraph
-AnchorPair = tuple[int, int]
-EdgeLabel = frozenset[int, int]
-AdjacentTranspositionGraph = nx.Graph
+type PartialOrder = list[tuple[int, int]]
+type CoverRelation = list[tuple[int, int]]
+type LinearOrder = str
+type AcyclicDiGraph = nx.DiGraph
+type HasseDiagram = nx.DiGraph
+type AnchorPair = tuple[int, int]
+type EdgeLabel = frozenset[int, int]
+type AdjacentTranspositionGraph = nx.Graph
 
 # not the same as upsilon: list[LinearOrder] as LinearExtensions must correspond to a poset
-LinearExtensions = list[LinearOrder]
+type LinearExtensions = list[LinearOrder]

--- a/backend/app/classes.py
+++ b/backend/app/classes.py
@@ -7,3 +7,7 @@ AcyclicDiGraph = nx.DiGraph
 HasseDiagram = nx.DiGraph
 AnchorPair = tuple[int, int]
 EdgeLabel = frozenset[int, int]
+AdjacentTranspositionGraph = nx.Graph
+
+# not the same as upsilon: list[LinearOrder] as LinearExtensions must correspond to a poset
+LinearExtensions = list[LinearOrder]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ import plotly.io as pio
 
 from app.posetvisualizer import PosetVisualizer
 from app.posetsolver import PosetSolver
+from app.posetutils import PosetUtils
 
 
 class GraphRequest(BaseModel):
@@ -73,21 +74,20 @@ def get_graph(
 @app.get("/solve")
 def solve_optimal_k_poset_cover(k: int, upsilon: list[str] = Query([])):
     try:
-        solver = PosetSolver(upsilon, k)
-        result = solver.solve()
-        if result:
-            result_posets, result_linear_orders = result
+        print(f"{k = }. k is not handled yet.")
+        result_linear_orders = PosetSolver.minimum_poset_cover(upsilon)
+        result_posets = [
+            PosetUtils.get_partial_order_of_convex(leg) for leg in result_linear_orders
+        ]
 
-            return JSONResponse(
-                content=json.dumps(
-                    {
-                        "resultPosets": result_posets,
-                        "resultLinearOrders": result_linear_orders,
-                    }
-                )
+        return JSONResponse(
+            content=json.dumps(
+                {
+                    "resultPosets": result_posets,
+                    "resultLinearOrders": result_linear_orders,
+                }
             )
-        else:
-            return JSONResponse(content=json.dumps({}))
+        )
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/backend/app/posetsolver.py
+++ b/backend/app/posetsolver.py
@@ -22,17 +22,19 @@ class PosetSolver:
 
     def minimum_poset_cover(
         self, upsilon: list[LinearOrder], verbose=False
-    ) -> list[list[LinearOrder]] | None:
+    ) -> list[LinearExtensions]:
         G = PosetUtils.get_atg_from_upsilon(upsilon)
-        solutions: dict[frozenset[LinearOrder], list[list[LinearOrder]]] = {}
+        solutions: dict[frozenset[LinearOrder], list[LinearExtensions]] = {}
         for connected_component in nx.connected_components(G):
-            upsilon1 = list(connected_component)
+            upsilon1: list[LinearOrder] = list(connected_component)
             solutions[frozenset(connected_component)] = (
                 self.minimum_poset_cover_of_connected_component(upsilon1, verbose)
             )
             if verbose:
                 print(f'\n{"-"*40}\n')
-        poset_cover = list(chain.from_iterable(solutions.values()))
+        poset_cover: list[LinearExtensions] = list(
+            chain.from_iterable(solutions.values())
+        )
         if verbose:
             print(
                 f"Input graph has {len(solutions)} connected component{'s' if len(solutions)>1 else ''}."
@@ -42,10 +44,10 @@ class PosetSolver:
 
     def minimum_poset_cover_of_connected_component(
         self, upsilon: list[LinearOrder], verbose=False
-    ) -> list[list[LinearOrder]] | None:
+    ) -> list[LinearExtensions]:
         """A parameterized algorithm which finds the minimum poset cover"""
         n = len(upsilon)
-        result = None
+        result: list[LinearExtensions] | None = None
         for k in range(1, n + 1):
             if k == 1:
                 convex = PosetUtils.generate_convex(upsilon)
@@ -62,14 +64,15 @@ class PosetSolver:
             elif verbose:
                 print(f"Failed to find a {k}-poset cover")
 
-            if result:
+            if result is not None:
                 break
 
+        assert result is not None
         return result
 
     def exact_k_poset_cover(
         self, upsilon: list[LinearOrder], k: int, verbose=False
-    ) -> list[list[LinearOrder]] | None:
+    ) -> list[LinearExtensions] | None:
         """Find a k-poset cover given upsilon. Static method."""
 
         if verbose:
@@ -159,7 +162,7 @@ class PosetSolver:
         anchor_pairs: list[AnchorPair],
         partial_order: PartialOrder,
         verbose=False,
-    ) -> list[LinearOrder]:
+    ) -> LinearExtensions:
         """
         Input: A set Y of linear orders, a set A of anchor pairs, and a poset P_A whose linear extensions are bounded by A,
             i.e L(P) subseteq Y and A subseteq P_A

--- a/backend/app/posetsolver.py
+++ b/backend/app/posetsolver.py
@@ -6,29 +6,18 @@ from app.classes import *
 
 
 class PosetSolver:
-    def __init__(self, upsilon, k=None):
-        self.upsilon = upsilon
-        self.k = k
-
-    def solve(self):
-        legs = None
-        if self.k and False:
-            legs = self.exact_k_poset_cover(self.upsilon, self.k)
-            legs = legs if legs else []
-        else:
-            legs = self.minimum_poset_cover(self.upsilon)
-        partial_orders = [PosetUtils.get_partial_order_of_convex(leg) for leg in legs]
-        return partial_orders, legs
-
+    @staticmethod
     def minimum_poset_cover(
-        self, upsilon: list[LinearOrder], verbose=False
+        upsilon: list[LinearOrder], verbose=False
     ) -> list[LinearExtensions]:
         G = PosetUtils.get_atg_from_upsilon(upsilon)
         solutions: dict[frozenset[LinearOrder], list[LinearExtensions]] = {}
         for connected_component in nx.connected_components(G):
             upsilon1: list[LinearOrder] = list(connected_component)
             solutions[frozenset(connected_component)] = (
-                self.minimum_poset_cover_of_connected_component(upsilon1, verbose)
+                PosetSolver._minimum_poset_cover_of_connected_component(
+                    upsilon1, verbose
+                )
             )
             if verbose:
                 print(f'\n{"-"*40}\n')
@@ -42,8 +31,9 @@ class PosetSolver:
             print(f"Combined solution: {poset_cover}")
         return poset_cover
 
-    def minimum_poset_cover_of_connected_component(
-        self, upsilon: list[LinearOrder], verbose=False
+    @staticmethod
+    def _minimum_poset_cover_of_connected_component(
+        upsilon: list[LinearOrder], verbose=False
     ) -> list[LinearExtensions]:
         """A parameterized algorithm which finds the minimum poset cover"""
         n = len(upsilon)
@@ -56,7 +46,7 @@ class PosetSolver:
             elif k == n:
                 result = [[linear_order] for linear_order in upsilon]
             else:
-                result = self.exact_k_poset_cover(upsilon, k)
+                result = PosetSolver.exact_k_poset_cover(upsilon, k)
 
             if verbose and result:
                 print(f"Found a {k}-poset cover")
@@ -70,8 +60,9 @@ class PosetSolver:
         assert result is not None
         return result
 
+    @staticmethod
     def exact_k_poset_cover(
-        self, upsilon: list[LinearOrder], k: int, verbose=False
+        upsilon: list[LinearOrder], k: int, verbose=False
     ) -> list[LinearExtensions] | None:
         """Find a k-poset cover given upsilon. Static method."""
 
@@ -132,7 +123,7 @@ class PosetSolver:
                     print(f"is_poset: {A_is_a_poset}")
 
             if A_is_a_poset:
-                maximal_supercover_linear_extensions = self.maximal_poset(
+                maximal_supercover_linear_extensions = PosetSolver.maximal_poset(
                     upsilon, list(anchor_pairs), partial_order_A
                 )
                 if verbose:
@@ -156,8 +147,8 @@ class PosetSolver:
                 return list(solution)
         return None
 
+    @staticmethod
     def maximal_poset(
-        self,
         upsilon: list[LinearOrder],
         anchor_pairs: list[AnchorPair],
         partial_order: PartialOrder,

--- a/backend/app/posetutils.py
+++ b/backend/app/posetutils.py
@@ -3,14 +3,14 @@ from app.classes import *
 
 class PosetUtils:
     @staticmethod
-    def get_atg_from_upsilon(upsilon: list[LinearOrder]):
+    def get_atg_from_upsilon(upsilon: list[LinearOrder]) -> AdjacentTranspositionGraph:
         """Get the Adjacent Transposition Graph of upsilon.
         
         Parameters \\
         upsilon (required) -- a list of linear orders. Linear orders must have equal lengths.
 
         Returns \\
-        nx.Graph
+        AdjacentTranspositionGraph aka nx.Graph
         """
         G = nx.Graph()
         G.add_nodes_from(upsilon)
@@ -24,7 +24,7 @@ class PosetUtils:
     @staticmethod
     def get_linear_extensions_from_graph(
         G: AcyclicDiGraph | HasseDiagram,
-    ) -> list[LinearOrder]:
+    ) -> LinearExtensions:
         """Get the linear extensions of a poset using either its hasse or directed acyclic graph representation.
 
         Returns a list of linear orders like ['1234','2134'].
@@ -33,7 +33,7 @@ class PosetUtils:
         G (required) -- a graph representation of the poset, either hasse or DAG, which are both nx.DiGraph
 
         Returns \\
-        List[LinearOrder] aka List[str]
+        LinearExtensions aka list[str]
         """
         sortings = list(nx.all_topological_sorts(G))
         return sorted(["".join(map(str, sorting)) for sorting in sortings])
@@ -41,7 +41,7 @@ class PosetUtils:
     @staticmethod
     def get_linear_extensions_from_relation(
         relation: PartialOrder | CoverRelation, sequence: str
-    ) -> list[LinearOrder]:
+    ) -> LinearExtensions:
         """Get the linear extensions of a poset using either its partial order or cover relation.
 
         Returns a list of linear orders like ['1234','2134'].
@@ -53,7 +53,7 @@ class PosetUtils:
             This ensures that ['1234','1243','1423','4123'] is returned and not ['123']
 
         Returns \\
-        List[LinearOrder] aka List[str]
+        LinearExtensions aka list[str]
         """
         G = nx.DiGraph()
         G.add_nodes_from(range(1, len(sequence) + 1))
@@ -119,7 +119,7 @@ class PosetUtils:
         G (required) -- a graph representation of the poset, either hasse or DAG, which are both nx.DiGraph
 
         Returns \\
-        Set[int]
+        set[int]
 
         Notes \\
         Example use case in the algorithm: \\
@@ -138,7 +138,7 @@ class PosetUtils:
         G (required) -- a graph representation of the poset, either hasse or DAG, which are both nx.DiGraph
 
         Returns \\
-        Set[int]
+        set[int]
 
         Notes \\
         Example use case in the algorithm: \\
@@ -277,14 +277,14 @@ class PosetUtils:
         return frozenset({x, y})
 
     @staticmethod
-    def generate_convex(linear_orders: list[LinearOrder]) -> list[LinearOrder]:
+    def generate_convex(linear_orders: list[LinearOrder]) -> LinearExtensions:
         """Get the smallest convex set of linear orders which contains the input.
         
         Parameters \\
         linear_orders (required) -- \\
         
         Returns \\
-        List[LinearOrder] aka List[str]
+        LinearExtensions aka list[str]
         """
         if not linear_orders:
             raise ValueError(
@@ -308,15 +308,15 @@ class PosetUtils:
         linear_orders (required) -- 
         
         Returns \\
-        PartialOrder aka List[Tuple[int,int]]
+        PartialOrder aka list[tuple[int,int]]
         """
         if not linear_orders:
             raise ValueError(
                 f"Cannot get conv(L) if L is empty. linear_orders={linear_orders}"
             )
 
-        def get_partial_order(linear_order: str) -> set:
-            partial_order = set()
+        def get_partial_order(linear_order: str) -> set[tuple[int, int]]:
+            partial_order: set[tuple[int, int]] = set()
             n = len(linear_order)
             for i in range(n):
                 for j in range(i + 1, n):

--- a/backend/tests/test_posetsolver.py
+++ b/backend/tests/test_posetsolver.py
@@ -47,92 +47,90 @@ from .upsilon_constants import (
 
 
 def test_minimum_poset_cover():
-    solver = PosetSolver(upsilon=[])
-    poset_cover = solver.minimum_poset_cover(TWOMAXIMAL)
+    poset_cover = PosetSolver.minimum_poset_cover(TWOMAXIMAL)
     assert set(TWOMAXIMAL) == set.union(*(set(leg) for leg in poset_cover))
     assert len(poset_cover) == 3
 
-    poset_cover = solver.minimum_poset_cover(GENMAXIMAL)
+    poset_cover = PosetSolver.minimum_poset_cover(GENMAXIMAL)
     assert set(GENMAXIMAL) == set.union(*(set(leg) for leg in poset_cover))
     assert len(poset_cover) == 2
 
-    poset_cover = solver.minimum_poset_cover(SQHEXPLUSLINE)
+    poset_cover = PosetSolver.minimum_poset_cover(SQHEXPLUSLINE)
     assert set(SQHEXPLUSLINE) == set.union(*(set(leg) for leg in poset_cover))
     assert len(poset_cover) == 2
 
-    poset_cover = solver.minimum_poset_cover(LINE295)
+    poset_cover = PosetSolver.minimum_poset_cover(LINE295)
     assert set(LINE295) == set.union(*(set(leg) for leg in poset_cover))
     assert len(poset_cover) == 1
 
-    poset_cover = solver.minimum_poset_cover(CUBELEG)
+    poset_cover = PosetSolver.minimum_poset_cover(CUBELEG)
     assert set(CUBELEG) == set.union(*(set(leg) for leg in poset_cover))
     assert len(poset_cover) == 1
 
-    poset_cover = solver.minimum_poset_cover(SINGLESIX)
+    poset_cover = PosetSolver.minimum_poset_cover(SINGLESIX)
     assert set(SINGLESIX) == set.union(*(set(leg) for leg in poset_cover))
     assert len(poset_cover) == 1
 
-    poset_cover = solver.minimum_poset_cover(HEX2SUNGAY)
+    poset_cover = PosetSolver.minimum_poset_cover(HEX2SUNGAY)
     assert set(HEX2SUNGAY) == set.union(*(set(leg) for leg in poset_cover))
     assert len(poset_cover) == 3
 
 
 def test_exact_k_poset_cover():
-    solver = PosetSolver(upsilon=[])
-    k_poset_cover = solver.exact_k_poset_cover(TWOMAXIMAL, 1)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(TWOMAXIMAL, 1)
     assert k_poset_cover is None
-    k_poset_cover = solver.exact_k_poset_cover(TWOMAXIMAL, 2)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(TWOMAXIMAL, 2)
     assert k_poset_cover is None
-    k_poset_cover = solver.exact_k_poset_cover(TWOMAXIMAL, 3)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(TWOMAXIMAL, 3)
     assert set(TWOMAXIMAL) == set.union(*(set(leg) for leg in k_poset_cover))
     assert len(k_poset_cover) == 3
 
-    k_poset_cover = solver.exact_k_poset_cover(GENMAXIMAL, 1)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(GENMAXIMAL, 1)
     assert k_poset_cover is None
-    k_poset_cover = solver.exact_k_poset_cover(GENMAXIMAL, 2)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(GENMAXIMAL, 2)
     assert set(GENMAXIMAL) == set.union(*(set(leg) for leg in k_poset_cover))
     assert len(k_poset_cover) == 2
 
     # exact_k_poset_cover does not accept disconnected graph inputs like SQHEXPLUSLINE
 
-    k_poset_cover = solver.exact_k_poset_cover(LINE295, 1)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(LINE295, 1)
     assert set(LINE295) == set.union(*(set(leg) for leg in k_poset_cover))
     assert len(k_poset_cover) == 1
-    k_poset_cover = solver.exact_k_poset_cover(LINE295, 2)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(LINE295, 2)
     assert set(LINE295) == set.union(*(set(leg) for leg in k_poset_cover))
     assert len(k_poset_cover) == 2
 
-    # k_poset_cover = solver.exact_k_poset_cover(LINE295, 3)
+    # k_poset_cover = PosetSolver.exact_k_poset_cover(LINE295, 3)
     # assert k_poset_cover is None
     # oh no. dapat pala unique yung laman ng PT*
     # next time nalang ayusin
 
     # undefined behavior for the following; needs consultation
-    # k_poset_cover = solver.exact_k_poset_cover(LINE295, 3)
+    # k_poset_cover = PosetSolver.exact_k_poset_cover(LINE295, 3)
     #   it is expected to not get any result according to line 296
     #   however, the algorithm returns None because it never gets to test any set of anchor pairs canonically
     #   this is due to the fact that a square LEG only has two swaps => four tuples to choose from
     #   !! my mistake. this should be possible because the choice is k-1 i.e. A_star = combinations(fourtuples, 3-1=2)
     #
-    # k_poset_cover = solver.exact_k_poset_cover(LINE295, 4)
+    # k_poset_cover = PosetSolver.exact_k_poset_cover(LINE295, 4)
     #   same case as above; this is now applicable as A_star = combinations(fourtuples, 3) => some cycle like (12,21,34) which no L will satisfy
     #   but, however, an answer is expected i.e. all of the four vertices
 
-    k_poset_cover = solver.exact_k_poset_cover(CUBELEG, 1)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(CUBELEG, 1)
     assert set(CUBELEG) == set.union(*(set(leg) for leg in k_poset_cover))
     assert len(k_poset_cover) == 1
     # testing for k>=2 is dubious because PT* contains duplicates
     # moreover, PT* will always contains copies of the single maximal poset, the cubeleg!
 
-    k_poset_cover = solver.exact_k_poset_cover(SINGLESIX, 1)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(SINGLESIX, 1)
     assert set(SINGLESIX) == set.union(*(set(leg) for leg in k_poset_cover))
     assert len(k_poset_cover) == 1
 
-    k_poset_cover = solver.exact_k_poset_cover(HEX2SUNGAY, 1)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(HEX2SUNGAY, 1)
     assert k_poset_cover is None
-    k_poset_cover = solver.exact_k_poset_cover(HEX2SUNGAY, 2)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(HEX2SUNGAY, 2)
     assert k_poset_cover is None
-    k_poset_cover = solver.exact_k_poset_cover(HEX2SUNGAY, 3)
+    k_poset_cover = PosetSolver.exact_k_poset_cover(HEX2SUNGAY, 3)
     assert set(HEX2SUNGAY) == set.union(*(set(leg) for leg in k_poset_cover))
     assert len(k_poset_cover) == 3
 
@@ -148,17 +146,16 @@ def test_maximal_poset():
     _4123_SNAKE = ["4123", "1423", "1243", "1234"]
 
     # for TWOMAXIMAL, we simulate k=3, meaning there are 2 anchor pairs
-    solver = PosetSolver(upsilon=[])
     seed_poset: list[LinearOrder] = ["2134"]
     anchor_pairs: list[AnchorPair] = [(2, 1), (3, 4)]
     partial_order: PartialOrder = PosetUtils.get_partial_order_of_convex(seed_poset)
-    maximal = solver.maximal_poset(TWOMAXIMAL, anchor_pairs, partial_order)
+    maximal = PosetSolver.maximal_poset(TWOMAXIMAL, anchor_pairs, partial_order)
     assert set(maximal) == set(_2134_SQHEX)
 
     seed_poset: list[LinearOrder] = ["3142", "3412"]
     anchor_pairs: list[AnchorPair] = [(4, 2), (3, 1)]
     partial_order: PartialOrder = PosetUtils.get_partial_order_of_convex(seed_poset)
-    maximal = solver.maximal_poset(TWOMAXIMAL, anchor_pairs, partial_order)
+    maximal = PosetSolver.maximal_poset(TWOMAXIMAL, anchor_pairs, partial_order)
     assert set(maximal) == set(_3412_DOWN_TO_1234)
 
     # consultation with mam. bakit po need ng anchor pairs? for example, isn't it sufficient
@@ -167,11 +164,11 @@ def test_maximal_poset():
     seed_poset: list[LinearOrder] = ["4123", "1423"]
     anchor_pairs: list[AnchorPair] = [(4, 2), (2, 3)]
     partial_order: PartialOrder = PosetUtils.get_partial_order_of_convex(seed_poset)
-    maximal = solver.maximal_poset(TWOMAXIMAL, anchor_pairs, partial_order)
+    maximal = PosetSolver.maximal_poset(TWOMAXIMAL, anchor_pairs, partial_order)
     assert set(maximal) == set(_4123_SNAKE)
 
     seed_poset: list[LinearOrder] = ["1432"]
     anchor_pairs: list[AnchorPair] = [(3, 2), (4, 3)]
     partial_order: PartialOrder = PosetUtils.get_partial_order_of_convex(seed_poset)
-    maximal = solver.maximal_poset(TWOMAXIMAL, anchor_pairs, partial_order)
+    maximal = PosetSolver.maximal_poset(TWOMAXIMAL, anchor_pairs, partial_order)
     assert set(maximal) == set(_3124_SQHEX)


### PR DESCRIPTION
- Add new type aliases: LinearExtensions and AdjacentTranspositionGraph
- Update return type of PosetSolver.minimum_poset_cover and .minimum_poset_cover_of_connected_component to exclude NoneType (well NoneType and None as types are apparently equivalent)
- convert PosetSolver methods to static and update the test file accordingly