### PR TITLE
Test posetvisualizer

### DIFF
--- a/backend/app/posetvisualizer.py
+++ b/backend/app/posetvisualizer.py
@@ -4,6 +4,8 @@ import networkx as nx
 import plotly.graph_objects as go
 import seaborn as sns
 
+from app.classes import *
+
 
 class NodeRenderSpecifiers(TypedDict):
     color: str
@@ -62,20 +64,29 @@ class PosetVisualizer:
                 f"Invalid size. Size must have a value of at least 2 and at most {self.MAX_SIZE}."
             )
 
-        self.size = size
-        self.selected_nodes = []
-        self.highlighted_nodes = []
+        self.size: int = size
+
+        self.selected_nodes: list[LinearOrder] = []
+        self.highlighted_nodes: list[LinearOrder] = []
+
+        self._graph: nx.Graph
+        # for the next properties, str means '1', '2', '3', etc. except for the values of _pair_to_color which are of course colors
+        self._pair_to_color: dict[tuple[str, str], str]
+        self._edges_by_swap: dict[
+            tuple[str, str], list[tuple[LinearOrder, LinearOrder]]
+        ]
+        self._fig: go.Figure
 
         self._set_up_graph()
         self._pos = nx.spring_layout(self._graph, dim=3, seed=42)
-        self._edge_trace = self._compute_edge_traces()
-        self._node_trace = self._compute_node_traces()
-        self._fig_layout = self._make_fig_layout()
+        self._edge_trace: list[go.Scatter3d] = self._compute_edge_traces()
+        self._node_trace: list[go.Scatter3d] = self._compute_node_traces()
+        self._fig_layout: go.Layout = self._make_fig_layout()
 
         self.update_figure()
 
     @staticmethod
-    def _get_swapped_numbers(p1: str, p2: str):
+    def _get_swapped_numbers(p1: str, p2: str) -> tuple[str, str]:
         """
         Returns the two numbers that were swapped between permutations,
         or None if not a valid adjacent transposition
@@ -104,7 +115,7 @@ class PosetVisualizer:
 
     def _set_up_graph(self):
         """Sets up graph and swap types"""
-        sequence = "".join(map(str, range(1, self.size + 1)))
+        sequence: str = "".join(map(str, range(1, self.size + 1)))
         number_pairs = list(combinations(sequence, 2))
         perm_strings = ["".join(p) for p in permutations(sequence)]
         self._graph = nx.Graph()

--- a/backend/app/posetvisualizer.py
+++ b/backend/app/posetvisualizer.py
@@ -7,28 +7,33 @@ import seaborn as sns
 from app.classes import *
 
 
-class NodeRenderSpecifiers(TypedDict):
+class NodeRenderSpecification(TypedDict):
     color: str
     size: int
     opacity: float
 
 
-class EdgeRenderSpecifiers(TypedDict):
+class EdgeRenderSpecification(TypedDict):
     color: str
     width: int
     opacity: float
 
 
+class EdgeRenderSpecificationForSelectedOther(TypedDict):
+    width: int
+    opacity: float
+
+
 class NodeRenderTypeSpecs(TypedDict):
-    selected: NodeRenderSpecifiers
-    highlighted: NodeRenderSpecifiers
-    other: NodeRenderSpecifiers
+    selected: NodeRenderSpecification
+    highlighted: NodeRenderSpecification
+    other: NodeRenderSpecification
 
 
 class EdgeRenderTypeSpecs(TypedDict):
-    selected: EdgeRenderSpecifiers
-    highlighted: EdgeRenderSpecifiers
-    other: EdgeRenderSpecifiers
+    selected: EdgeRenderSpecificationForSelectedOther
+    highlighted: EdgeRenderSpecification
+    other: EdgeRenderSpecificationForSelectedOther
 
 
 class RenderTypeSpecs(TypedDict):
@@ -49,9 +54,9 @@ class PosetVisualizer:
             "other": {"color": "black", "size": 3, "opacity": 0.1},
         },
         "edge": {
-            "selected": {"color": "", "width": 3, "opacity": 1},
+            "selected": {"width": 3, "opacity": 1},
             "highlighted": {"color": "red", "width": 5, "opacity": 1},
-            "other": {"color": "", "width": 3, "opacity": 0.1},
+            "other": {"width": 3, "opacity": 0.1},
         },
         # showlegend is also affected by render_type but not specified in this specs
     }
@@ -317,14 +322,14 @@ class PosetVisualizer:
     def _all_perms_are_selected(self):
         return len(self.selected_nodes) == 0
 
-    def select_nodes(self, select_nodes: list[str]):
+    def select_nodes(self, select_nodes: list[LinearOrder]):
         """Selects specified nodes"""
         self.selected_nodes = select_nodes
         self._node_trace = self._compute_node_traces()
         self._edge_trace = self._compute_edge_traces()
         self.update_figure()
 
-    def highlight_nodes(self, select_nodes: list[str]):
+    def highlight_nodes(self, select_nodes: list[LinearOrder]):
         """Highlights specified nodes"""
         self.highlighted_nodes = select_nodes
         self._node_trace = self._compute_node_traces()
@@ -332,7 +337,7 @@ class PosetVisualizer:
         self.update_figure()
 
     def select_and_highlight_nodes(
-        self, select_nodes: list[str], highlight_nodes: list[str]
+        self, select_nodes: list[LinearOrder], highlight_nodes: list[LinearOrder]
     ):
         self.highlighted_nodes = highlight_nodes
         self.selected_nodes = select_nodes

--- a/backend/tests/test_posetvisualizer.py
+++ b/backend/tests/test_posetvisualizer.py
@@ -1,3 +1,59 @@
+"""
+Test Overview
+
+Public interface of a PosetVisualizer (✓ - for testing; ✗ - maybe not)
+ - select_nodes                 ✓ function is useful
+ - highlight_nodes              ✗ not useful on its own
+ - select_and_highlight_nodes   ✓ function is useful
+ - update_figure                ✗ used only by the select node methods
+ - show_figure                  ✗ not used
+ - get_figure_data              ✓ main purpose of the visualizer
+
+Some notes regarding the purpose of the select-node functions
+    There are three classes of vertices and edges: selected, highlighted, and others
+    All vertices and edges start as "others"
+    select_nodes will move some vertices (and their edges) to "selected" class/status
+    highlight_nodes will move some vertices (and their edges) to "highlighted" class/status
+    select_and_highlight_nodes does both
+    Only then is get_figure called (see main.py)
+
+
+Charateristics of Nodes and Edges according to Class
+    +-------------------+-------------------+-------------------+
+    |       Class       |      Vertex       |       Edge        |
+    +-------------------+-------------------+-------------------+
+    |     Selected      |   color="black"   |color=<swap_color> |
+    |                   |      size=3       |      width=2      |
+    |                   |     opacity=1     |     opacity=1     |
+    +-------------------+-------------------+-------------------+
+    |    Highlighted    |    color="red"    |    color="red"    |
+    |                   |      size=6       |      width=5      |
+    |                   |     opacity=1     |     opacity=1     |
+    +-------------------+-------------------+-------------------+
+    |      Others       |   color="black"   |color=<swap_color> |
+    |                   |      size=3       |      width=2      |
+    |                   |    opacity=0.1    |    opacity=0.1    |
+    +-------------------+-------------------+-------------------+
+
+    Observations after investigating the traces.
+        Except for the variable color (<swap_color>), colors red and black can be verified as literals "red" and "black"
+        Then other attributes can be check for their numerical value
+
+Proposed Test Organization
+1. test "default" output (i.e. without selection; permutahedron)
+    Call PosetVisualizer(n) for n = 3 to 5
+    a. edges
+    b. nodes
+2. test select_nodes
+    Call PosetVisualizer(n) for n = 3 and 4, then call .select_nodes()
+    a. edges
+    b. nodes
+3. test select_and_highlight_nodes()
+    Call PosetVisualizer(n) for n = 3 and 4, then call .select_and_highlight_nodes()
+    a. edges
+    b. nodes
+"""
+
 import pytest
 
 from app.posetvisualizer import PosetVisualizer

--- a/backend/tests/test_posetvisualizer.py
+++ b/backend/tests/test_posetvisualizer.py
@@ -43,6 +43,7 @@ New Test Proposal
 Now, since it is clear we are operating with three render types, I suppose we should not test for the definition anymore.
 (Notice that the ATG in the paper does not deal with highlighted edges, nor "other" nodes.)
 Instead, we should simply test for the render types and hope that our representation still contains the ATG.
+It should also be noted that there is no test for .get_figure_data as its reliability is guaranteed by all the tests.
 1. test_errors_raised
 2. test "default" output (i.e. without selection; permutahedron). effectively the same as .select_nodes(<all_nodes>)
     Call PosetVisualizer(n) for n = 3 and 4
@@ -70,80 +71,157 @@ RENDER_TYPE_SPECS = PosetVisualizer.RENDER_TYPE_SPECS
 
 def _verify_edges_have_the_same_color(
     tester: FigureTester, edges: list[tuple[str, str]]
-) -> bool:
-    """Verify edges provided all have the same color. Not applicable to lists containing highlighted edges.
+) -> None:
+    """Verify all edges provided have the same color. Not applicable to lists containing highlighted edges.
 
     Equivalent to verifying that all edges have the same swap, i.e. same equivalence class
     """
     edge0 = edges[0]
-    color0 = tester.get_edge_data(*edge0)["line"]["color"]
+    edge_data0 = tester.get_edge_data(*edge0)
+
+    assert (
+        edge_data0
+    ), f"edge '{edge0}', while expected to exist, does not exist in figure data"
+
+    color0 = edge_data0["line"]["color"]
     for edge in edges[1:]:
-        color = tester.get_edge_data(*edge)["line"]["color"]
-        if color != color0:
-            return False
-    return True
+        edge_data = tester.get_edge_data(*edge)
+
+        assert (
+            edge_data
+        ), f"edge '{edge}', while expected to exist, does not exist in figure data"
+
+        color = edge_data["line"]["color"]
+
+        assert (
+            color == color0
+        ), f"expected {{edge: {edge}, color: {color} }} to have the same color as {{edge0: {edge0}, color: {color0} }}"
 
 
-def _verify_edges_do_not_exist(tester, edges) -> bool:
+def _verify_edges_have_different_colors(
+    tester: FigureTester, edge1: tuple[str, str], edge2: tuple[str, str]
+) -> None:
+    """Verify that TWO edges differ in color. Not applicable to highlighted edges"""
+    edge_data1 = tester.get_edge_data(*edge1)
+    edge_data2 = tester.get_edge_data(*edge2)
+
+    assert (
+        edge_data1
+    ), f"edge '{edge1}', while expected to exist, does not exist in figure data"
+    assert (
+        edge_data2
+    ), f"edge '{edge2}', while expected to exist, does not exist in figure data"
+
+    color1 = edge_data1["line"]["color"]
+    color2 = edge_data2["line"]["color"]
+
+    assert (
+        color1 != color2
+    ), f"expected {{edge1: {edge1}, color: {color1} }} to have a different color than {{edge2: {edge2}, color: {color2} }}"
+
+
+def _verify_edges_do_not_exist(tester, edges) -> None:
     """Verify if all edges provided are NOT part of the atg
 
-    Edges which differ with more than one adjacent swap should not be part of the atg
+    Any two permutations with one unreachable by an adjacent swap from the other should not constitute an edge\\
+    That is, an "edge" between such permutations should not be part of the atg
+
+    This function is usually used to check if the "edge" adheres to the definition of atg's\\
+    In the future, we should perhaps check for edges not found in the supercover,
+        or simply create new functions
     """
     for node_text1, node_text2 in edges:
         edge_data = tester.get_edge_data(node_text1, node_text2)
-        if edge_data is not None:
-            return False  # f"edge provided '{(node_text1, node_text2)}', while expected to not exist, does exist in figure data"
-    return True
+        assert (
+            edge_data is None
+        ), f"edge '{(node_text1, node_text2)}', while expected to not exist, does exist in figure data"
+
+
+def _verify_render_type_of_node(
+    tester: FigureTester, node_text: str, render_type: RenderType
+) -> bool:
+    """Verify that the node is rendered as render_type
+
+    Args:
+        tester: The object containing the traces
+        node_text: The text of the node like '1234', a LinearOrder
+        render_type: The expected render type of the node
+
+    Returns:
+        bool:
+    """
+    node_data = tester.get_node_data(node_text)
+    assert (
+        node_data
+    ), f"node '{node_text}', while expected to exist, does not exist in figure data"
+
+    render_type_color = RENDER_TYPE_SPECS["node"][render_type]["color"]
+    render_type_size = RENDER_TYPE_SPECS["node"][render_type]["size"]
+    render_type_opacity = RENDER_TYPE_SPECS["node"][render_type]["opacity"]
+    color = node_data["marker"]["color"]
+    size = node_data["marker"]["size"]
+    opacity = node_data["opacity"]
+
+    same_color = color == render_type_color
+    same_size = size == render_type_size
+    same_opacity = opacity == render_type_opacity
+    return same_color and same_size and same_opacity
+
+
+def _verify_render_type_of_edge(
+    tester: FigureTester, edge: tuple[str, str], render_type: RenderType
+) -> bool:
+    """Verify that the edge is rendered as render_type
+
+    Args:
+        tester: The object containing the traces
+        edge: An edge described by the text of its nodes, e.g. tuple('123','213')
+        render_type: The expected render type of the edge
+
+    Returns:
+        bool:
+    """
+    node_text1, node_text2 = edge
+    edge_data = tester.get_edge_data(node_text1, node_text2)
+    assert (
+        edge_data
+    ), f"edge '{(node_text1, node_text2)}', while expected to exist, does not exist in figure data"
+
+    highlighted_color = RENDER_TYPE_SPECS["edge"]["highlighted"]["color"]
+    render_type_width = RENDER_TYPE_SPECS["edge"][render_type]["width"]
+    render_type_opacity = RENDER_TYPE_SPECS["edge"][render_type]["opacity"]
+    color = edge_data["line"]["color"]
+    width = edge_data["line"]["width"]
+    opacity = edge_data["opacity"]
+
+    color_is_ok = render_type != "highlighted" or color == highlighted_color
+    same_width = width == render_type_width
+    same_opacity = opacity == render_type_opacity
+    return color_is_ok and same_width and same_opacity
 
 
 def _verify_render_type_of_nodes(
     tester: FigureTester, nodes: list[str], render_type: RenderType
-) -> bool:
-    render_type_color = RENDER_TYPE_SPECS["node"][render_type]["color"]
-    render_type_size = RENDER_TYPE_SPECS["node"][render_type]["size"]
-    render_type_opacity = RENDER_TYPE_SPECS["node"][render_type]["opacity"]
+) -> None:
+    """Verify that the nodes are rendered as render_type"""
     for node_text in nodes:
-        node_data = tester.get_node_data(node_text)
+        is_correctly_rendered = _verify_render_type_of_node(
+            tester, node_text, render_type
+        )
         assert (
-            node_data
-        ), f"node '{node_text}', while expected to exist, does not exist in figure data"
-        color = node_data["marker"]["color"]
-        size = node_data["marker"]["size"]
-        opacity = node_data["opacity"]
-        if not all(
-            [
-                color == render_type_color,
-                size == render_type_size,
-                opacity == render_type_opacity,
-            ]
-        ):
-            return False
-    return True
+            is_correctly_rendered
+        ), f'expected node "{node_text}" is rendered as "{render_type}", but it\'s not'
 
 
 def _verify_render_type_of_edges(
     tester: FigureTester, edges: list[tuple[str, str]], render_type: RenderType
-) -> bool:
-    highlighted_color = RENDER_TYPE_SPECS["edge"]["highlighted"]["color"]
-    render_type_width = RENDER_TYPE_SPECS["edge"][render_type]["width"]
-    render_type_opacity = RENDER_TYPE_SPECS["edge"][render_type]["opacity"]
-    for node_text1, node_text2 in edges:
-        edge_data = tester.get_edge_data(node_text1, node_text2)
+) -> None:
+    """Verify that the edges are rendered as render_type"""
+    for edge in edges:
+        is_correctly_rendered = _verify_render_type_of_edge(tester, edge, render_type)
         assert (
-            edge_data
-        ), f"edge '{(node_text1, node_text2)}', while expected to exist, does not exist in figure data"
-        color = edge_data["line"]["color"]
-        width = edge_data["line"]["width"]
-        opacity = edge_data["opacity"]
-        if not all(
-            [
-                render_type != "highlighted" or color == highlighted_color,
-                width == render_type_width,
-                opacity == render_type_opacity,
-            ]
-        ):
-            return False
-    return True
+            is_correctly_rendered
+        ), f'expected edge "{edge}" is rendered as "{render_type}", but it\'s not'
 
 
 def test_errors_raised():
@@ -165,7 +243,7 @@ def test_default_behavior():
     # selected/highlighted nodes are part of the atg
     # for this case, there are no "highlighted", "other", and "does not exist" nodes to check
     selected_nodes = ["123", "132", "213", "231", "312", "321"]
-    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
 
     # selected/highlighted edges are part of the atg, other edges are "visual aids"
     # for this case, there are no "highlighted" and "other" edges to check
@@ -176,16 +254,16 @@ def test_default_behavior():
         ("123", "231"),
         ("312", "213"),
     ]
-    assert _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
-    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     edge_12 = [("123", "213"), ("312", "321")]
     edge_23 = [("123", "132"), ("231", "321")]
     diff_swap = [("123", "132"), ("123", "213")]
-    assert _verify_edges_have_the_same_color(tester, edge_23)
-    assert _verify_edges_have_the_same_color(tester, edge_12)
-    assert not _verify_edges_have_the_same_color(tester, diff_swap)
+    _verify_edges_have_the_same_color(tester, edge_23)
+    _verify_edges_have_the_same_color(tester, edge_12)
+    _verify_edges_have_different_colors(tester, *diff_swap)
 
     # ============ Size 4 ============ #
     visualizer = PosetVisualizer(4)
@@ -194,9 +272,7 @@ def test_default_behavior():
     # selected/highlighted nodes are part of the atg
     # for this case, there are no "highlighted", "other", and "does not exist" nodes to check
     some_selected_nodes = ["1243", "1432", "2134", "2431", "4312", "3214"]
-    assert _verify_render_type_of_nodes(
-        tester, some_selected_nodes, render_type="selected"
-    )
+    _verify_render_type_of_nodes(tester, some_selected_nodes, render_type="selected")
 
     # selected/highlighted edges are part of the atg, other edges are "visual aids"
     # for this case, there are no "highlighted" and "other" edges to check
@@ -207,18 +283,16 @@ def test_default_behavior():
         ("1243", "2341"),
         ("4312", "4213"),
     ]
-    assert _verify_render_type_of_edges(
-        tester, some_selected_edges, render_type="selected"
-    )
-    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    _verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
+    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     edge_14 = [("2143", "2413"), ("3214", "3241"), ("1423", "4123")]
     edge_24 = [("1243", "1423"), ("2413", "4213"), ("1324", "1342")]
     diff_swap = [("1243", "1423"), ("1423", "4123")]
-    assert _verify_edges_have_the_same_color(tester, edge_14)
-    assert _verify_edges_have_the_same_color(tester, edge_24)
-    assert not _verify_edges_have_the_same_color(tester, diff_swap)
+    _verify_edges_have_the_same_color(tester, edge_14)
+    _verify_edges_have_the_same_color(tester, edge_24)
+    _verify_edges_have_different_colors(tester, *diff_swap)
 
 
 def test_select_nodes():
@@ -232,8 +306,8 @@ def test_select_nodes():
     # for this case, there are no "highlighted", and "does not exist" nodes to check
     selected_nodes = selected_nodes
     other_nodes = ["231", "213"]
-    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
-    assert _verify_render_type_of_nodes(tester, other_nodes, render_type="other")
+    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    _verify_render_type_of_nodes(tester, other_nodes, render_type="other")
 
     # selected edges are part of the atg, other edges are "visual aids"
     # for this case, there are no "highlighted" edges to check
@@ -245,18 +319,18 @@ def test_select_nodes():
         ("123", "231"),
         ("312", "213"),
     ]
-    assert _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
-    assert _verify_render_type_of_edges(tester, other_edges, render_type="other")
-    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    _verify_render_type_of_edges(tester, other_edges, render_type="other")
+    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     # in this case, no "selected" edges have the same color
     diff_swap1 = [("123", "132"), ("132", "312")]
     diff_swap2 = [("123", "132"), ("312", "321")]
     diff_swap3 = [("132", "312"), ("312", "321")]
-    assert not _verify_edges_have_the_same_color(tester, diff_swap1)
-    assert not _verify_edges_have_the_same_color(tester, diff_swap2)
-    assert not _verify_edges_have_the_same_color(tester, diff_swap3)
+    _verify_edges_have_different_colors(tester, *diff_swap1)
+    _verify_edges_have_different_colors(tester, *diff_swap2)
+    _verify_edges_have_different_colors(tester, *diff_swap3)
 
     # ============ Size 4 ============ #
     visualizer = PosetVisualizer(4)
@@ -268,29 +342,27 @@ def test_select_nodes():
     # for this case, there are no "highlighted" and "does not exist" nodes to check
     selected_nodes = selected_nodes
     some_other_nodes = ["4321", "4231", "2413"]
-    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
-    assert _verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
+    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    _verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
 
     # selected/highlighted edges are part of the atg, other edges are "visual aids"
     # for this case, there are no "highlighted" edges to check
     some_selected_edges = [("2134", "2143"), ("1234", "1324"), ("3142", "3412")]
     some_other_edges = [("4321", "4231"), ("2143", "2413")]
     some_edges_that_dont_exist = [("1243", "3142"), ("4123", "4321"), ("1234", "2314")]
-    assert _verify_render_type_of_edges(
-        tester, some_selected_edges, render_type="selected"
-    )
-    assert _verify_render_type_of_edges(tester, some_other_edges, render_type="other")
-    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    _verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
+    _verify_render_type_of_edges(tester, some_other_edges, render_type="other")
+    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     edge_24 = [("3124", "3142"), ("1324", "1342"), ("1243", "1423")]
     edge_13 = [("3124", "1324"), ("3142", "1342")]
     edge_23 = [("1423", "1432"), ("1234", "1324")]
     diff_swap = [("2134", "2143"), ("1234", "2134")]
-    assert _verify_edges_have_the_same_color(tester, edge_24)
-    assert _verify_edges_have_the_same_color(tester, edge_13)
-    assert _verify_edges_have_the_same_color(tester, edge_23)
-    assert not _verify_edges_have_the_same_color(tester, diff_swap)
+    _verify_edges_have_the_same_color(tester, edge_24)
+    _verify_edges_have_the_same_color(tester, edge_13)
+    _verify_edges_have_the_same_color(tester, edge_23)
+    _verify_edges_have_different_colors(tester, *diff_swap)
 
 
 def test_select_and_highlight_nodes():
@@ -306,11 +378,9 @@ def test_select_and_highlight_nodes():
     selected_nodes = ["321"]
     other_nodes = ["231", "213"]
     highlighted_nodes = highlighted_nodes
-    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
-    assert _verify_render_type_of_nodes(tester, other_nodes, render_type="other")
-    assert _verify_render_type_of_nodes(
-        tester, highlighted_nodes, render_type="highlighted"
-    )
+    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    _verify_render_type_of_nodes(tester, other_nodes, render_type="other")
+    _verify_render_type_of_nodes(tester, highlighted_nodes, render_type="highlighted")
 
     # selected edges are part of the atg, other edges are "visual aids"
     selected_edges = [("312", "321")]
@@ -322,12 +392,10 @@ def test_select_and_highlight_nodes():
         ("123", "231"),
         ("312", "213"),
     ]
-    assert _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
-    assert _verify_render_type_of_edges(tester, other_edges, render_type="other")
-    assert _verify_render_type_of_edges(
-        tester, highlighted_edges, render_type="highlighted"
-    )
-    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    _verify_render_type_of_edges(tester, other_edges, render_type="other")
+    _verify_render_type_of_edges(tester, highlighted_edges, render_type="highlighted")
+    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     # in this case, two out of three edges are highlighted, so nothing to test
@@ -344,32 +412,26 @@ def test_select_and_highlight_nodes():
     selected_nodes = list(set(TWOMAXIMAL) - set(highlighted_nodes))
     some_other_nodes = ["4321", "4231", "2413"]
     highlighted_nodes = highlighted_nodes
-    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
-    assert _verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
-    assert _verify_render_type_of_nodes(
-        tester, highlighted_nodes, render_type="highlighted"
-    )
+    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    _verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
+    _verify_render_type_of_nodes(tester, highlighted_nodes, render_type="highlighted")
 
     # selected/highlighted edges are part of the atg, other edges are "visual aids"
     some_selected_edges = [("2134", "2143"), ("1234", "1324"), ("3142", "3412")]
     some_other_edges = [("4321", "4231"), ("2143", "2413")]
     highlighted_edges = [("4123", "1423"), ("1423", "1243"), ("1243", "1234")]
     some_edges_that_dont_exist = [("1243", "3142"), ("4123", "4321"), ("1234", "2314")]
-    assert _verify_render_type_of_edges(
-        tester, some_selected_edges, render_type="selected"
-    )
-    assert _verify_render_type_of_edges(tester, some_other_edges, render_type="other")
-    assert _verify_render_type_of_edges(
-        tester, highlighted_edges, render_type="highlighted"
-    )
-    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    _verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
+    _verify_render_type_of_edges(tester, some_other_edges, render_type="other")
+    _verify_render_type_of_edges(tester, highlighted_edges, render_type="highlighted")
+    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     edge_24 = [("3124", "3142"), ("1324", "1342")]
     edge_13 = [("3124", "1324"), ("3142", "1342")]
     edge_23 = [("1423", "1432"), ("1234", "1324")]
     diff_swap = [("2134", "2143"), ("1234", "2134")]
-    assert _verify_edges_have_the_same_color(tester, edge_24)
-    assert _verify_edges_have_the_same_color(tester, edge_13)
-    assert _verify_edges_have_the_same_color(tester, edge_23)
-    assert not _verify_edges_have_the_same_color(tester, diff_swap)
+    _verify_edges_have_the_same_color(tester, edge_24)
+    _verify_edges_have_the_same_color(tester, edge_13)
+    _verify_edges_have_the_same_color(tester, edge_23)
+    _verify_edges_have_different_colors(tester, *diff_swap)

--- a/backend/tests/test_posetvisualizer.py
+++ b/backend/tests/test_posetvisualizer.py
@@ -69,7 +69,7 @@ from .upsilon_constants import TWOMAXIMAL
 RENDER_TYPE_SPECS = PosetVisualizer.RENDER_TYPE_SPECS
 
 
-def _verify_edges_have_the_same_color(
+def verify_edges_have_the_same_color(
     tester: FigureTester, edges: list[tuple[str, str]]
 ) -> None:
     """Verify all edges provided have the same color. Not applicable to lists containing highlighted edges.
@@ -98,7 +98,7 @@ def _verify_edges_have_the_same_color(
         ), f"expected {{edge: {edge}, color: {color} }} to have the same color as {{edge0: {edge0}, color: {color0} }}"
 
 
-def _verify_edges_have_different_colors(
+def verify_edges_have_different_colors(
     tester: FigureTester, edge1: tuple[str, str], edge2: tuple[str, str]
 ) -> None:
     """Verify that TWO edges differ in color. Not applicable to highlighted edges"""
@@ -120,7 +120,7 @@ def _verify_edges_have_different_colors(
     ), f"expected {{edge1: {edge1}, color: {color1} }} to have a different color than {{edge2: {edge2}, color: {color2} }}"
 
 
-def _verify_edges_do_not_exist(tester, edges) -> None:
+def verify_edges_do_not_exist(tester, edges) -> None:
     """Verify if all edges provided are NOT part of the atg
 
     Any two permutations with one unreachable by an adjacent swap from the other should not constitute an edge\\
@@ -137,7 +137,7 @@ def _verify_edges_do_not_exist(tester, edges) -> None:
         ), f"edge '{(node_text1, node_text2)}', while expected to not exist, does exist in figure data"
 
 
-def _verify_render_type_of_node(
+def verify_render_type_of_node(
     tester: FigureTester, node_text: str, render_type: RenderType
 ) -> bool:
     """Verify that the node is rendered as render_type
@@ -168,7 +168,7 @@ def _verify_render_type_of_node(
     return same_color and same_size and same_opacity
 
 
-def _verify_render_type_of_edge(
+def verify_render_type_of_edge(
     tester: FigureTester, edge: tuple[str, str], render_type: RenderType
 ) -> bool:
     """Verify that the edge is rendered as render_type
@@ -200,12 +200,12 @@ def _verify_render_type_of_edge(
     return color_is_ok and same_width and same_opacity
 
 
-def _verify_render_type_of_nodes(
+def verify_render_type_of_nodes(
     tester: FigureTester, nodes: list[str], render_type: RenderType
 ) -> None:
     """Verify that the nodes are rendered as render_type"""
     for node_text in nodes:
-        is_correctly_rendered = _verify_render_type_of_node(
+        is_correctly_rendered = verify_render_type_of_node(
             tester, node_text, render_type
         )
         assert (
@@ -213,12 +213,12 @@ def _verify_render_type_of_nodes(
         ), f'expected node "{node_text}" is rendered as "{render_type}", but it\'s not'
 
 
-def _verify_render_type_of_edges(
+def verify_render_type_of_edges(
     tester: FigureTester, edges: list[tuple[str, str]], render_type: RenderType
 ) -> None:
     """Verify that the edges are rendered as render_type"""
     for edge in edges:
-        is_correctly_rendered = _verify_render_type_of_edge(tester, edge, render_type)
+        is_correctly_rendered = verify_render_type_of_edge(tester, edge, render_type)
         assert (
             is_correctly_rendered
         ), f'expected edge "{edge}" is rendered as "{render_type}", but it\'s not'
@@ -243,7 +243,7 @@ def test_default_behavior():
     # selected/highlighted nodes are part of the atg
     # for this case, there are no "highlighted", "other", and "does not exist" nodes to check
     selected_nodes = ["123", "132", "213", "231", "312", "321"]
-    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
 
     # selected/highlighted edges are part of the atg, other edges are "visual aids"
     # for this case, there are no "highlighted" and "other" edges to check
@@ -254,16 +254,16 @@ def test_default_behavior():
         ("123", "231"),
         ("312", "213"),
     ]
-    _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
-    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     edge_12 = [("123", "213"), ("312", "321")]
     edge_23 = [("123", "132"), ("231", "321")]
     diff_swap = [("123", "132"), ("123", "213")]
-    _verify_edges_have_the_same_color(tester, edge_23)
-    _verify_edges_have_the_same_color(tester, edge_12)
-    _verify_edges_have_different_colors(tester, *diff_swap)
+    verify_edges_have_the_same_color(tester, edge_23)
+    verify_edges_have_the_same_color(tester, edge_12)
+    verify_edges_have_different_colors(tester, *diff_swap)
 
     # ============ Size 4 ============ #
     visualizer = PosetVisualizer(4)
@@ -272,7 +272,7 @@ def test_default_behavior():
     # selected/highlighted nodes are part of the atg
     # for this case, there are no "highlighted", "other", and "does not exist" nodes to check
     some_selected_nodes = ["1243", "1432", "2134", "2431", "4312", "3214"]
-    _verify_render_type_of_nodes(tester, some_selected_nodes, render_type="selected")
+    verify_render_type_of_nodes(tester, some_selected_nodes, render_type="selected")
 
     # selected/highlighted edges are part of the atg, other edges are "visual aids"
     # for this case, there are no "highlighted" and "other" edges to check
@@ -283,16 +283,16 @@ def test_default_behavior():
         ("1243", "2341"),
         ("4312", "4213"),
     ]
-    _verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
-    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
+    verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     edge_14 = [("2143", "2413"), ("3214", "3241"), ("1423", "4123")]
     edge_24 = [("1243", "1423"), ("2413", "4213"), ("1324", "1342")]
     diff_swap = [("1243", "1423"), ("1423", "4123")]
-    _verify_edges_have_the_same_color(tester, edge_14)
-    _verify_edges_have_the_same_color(tester, edge_24)
-    _verify_edges_have_different_colors(tester, *diff_swap)
+    verify_edges_have_the_same_color(tester, edge_14)
+    verify_edges_have_the_same_color(tester, edge_24)
+    verify_edges_have_different_colors(tester, *diff_swap)
 
 
 def test_select_nodes():
@@ -306,8 +306,8 @@ def test_select_nodes():
     # for this case, there are no "highlighted", and "does not exist" nodes to check
     selected_nodes = selected_nodes
     other_nodes = ["231", "213"]
-    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
-    _verify_render_type_of_nodes(tester, other_nodes, render_type="other")
+    verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    verify_render_type_of_nodes(tester, other_nodes, render_type="other")
 
     # selected edges are part of the atg, other edges are "visual aids"
     # for this case, there are no "highlighted" edges to check
@@ -319,18 +319,18 @@ def test_select_nodes():
         ("123", "231"),
         ("312", "213"),
     ]
-    _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
-    _verify_render_type_of_edges(tester, other_edges, render_type="other")
-    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    verify_render_type_of_edges(tester, other_edges, render_type="other")
+    verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     # in this case, no "selected" edges have the same color
     diff_swap1 = [("123", "132"), ("132", "312")]
     diff_swap2 = [("123", "132"), ("312", "321")]
     diff_swap3 = [("132", "312"), ("312", "321")]
-    _verify_edges_have_different_colors(tester, *diff_swap1)
-    _verify_edges_have_different_colors(tester, *diff_swap2)
-    _verify_edges_have_different_colors(tester, *diff_swap3)
+    verify_edges_have_different_colors(tester, *diff_swap1)
+    verify_edges_have_different_colors(tester, *diff_swap2)
+    verify_edges_have_different_colors(tester, *diff_swap3)
 
     # ============ Size 4 ============ #
     visualizer = PosetVisualizer(4)
@@ -342,27 +342,27 @@ def test_select_nodes():
     # for this case, there are no "highlighted" and "does not exist" nodes to check
     selected_nodes = selected_nodes
     some_other_nodes = ["4321", "4231", "2413"]
-    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
-    _verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
+    verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
 
     # selected/highlighted edges are part of the atg, other edges are "visual aids"
     # for this case, there are no "highlighted" edges to check
     some_selected_edges = [("2134", "2143"), ("1234", "1324"), ("3142", "3412")]
     some_other_edges = [("4321", "4231"), ("2143", "2413")]
     some_edges_that_dont_exist = [("1243", "3142"), ("4123", "4321"), ("1234", "2314")]
-    _verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
-    _verify_render_type_of_edges(tester, some_other_edges, render_type="other")
-    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
+    verify_render_type_of_edges(tester, some_other_edges, render_type="other")
+    verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     edge_24 = [("3124", "3142"), ("1324", "1342"), ("1243", "1423")]
     edge_13 = [("3124", "1324"), ("3142", "1342")]
     edge_23 = [("1423", "1432"), ("1234", "1324")]
     diff_swap = [("2134", "2143"), ("1234", "2134")]
-    _verify_edges_have_the_same_color(tester, edge_24)
-    _verify_edges_have_the_same_color(tester, edge_13)
-    _verify_edges_have_the_same_color(tester, edge_23)
-    _verify_edges_have_different_colors(tester, *diff_swap)
+    verify_edges_have_the_same_color(tester, edge_24)
+    verify_edges_have_the_same_color(tester, edge_13)
+    verify_edges_have_the_same_color(tester, edge_23)
+    verify_edges_have_different_colors(tester, *diff_swap)
 
 
 def test_select_and_highlight_nodes():
@@ -378,9 +378,9 @@ def test_select_and_highlight_nodes():
     selected_nodes = ["321"]
     other_nodes = ["231", "213"]
     highlighted_nodes = highlighted_nodes
-    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
-    _verify_render_type_of_nodes(tester, other_nodes, render_type="other")
-    _verify_render_type_of_nodes(tester, highlighted_nodes, render_type="highlighted")
+    verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    verify_render_type_of_nodes(tester, other_nodes, render_type="other")
+    verify_render_type_of_nodes(tester, highlighted_nodes, render_type="highlighted")
 
     # selected edges are part of the atg, other edges are "visual aids"
     selected_edges = [("312", "321")]
@@ -392,10 +392,10 @@ def test_select_and_highlight_nodes():
         ("123", "231"),
         ("312", "213"),
     ]
-    _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
-    _verify_render_type_of_edges(tester, other_edges, render_type="other")
-    _verify_render_type_of_edges(tester, highlighted_edges, render_type="highlighted")
-    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    verify_render_type_of_edges(tester, other_edges, render_type="other")
+    verify_render_type_of_edges(tester, highlighted_edges, render_type="highlighted")
+    verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     # in this case, two out of three edges are highlighted, so nothing to test
@@ -412,26 +412,26 @@ def test_select_and_highlight_nodes():
     selected_nodes = list(set(TWOMAXIMAL) - set(highlighted_nodes))
     some_other_nodes = ["4321", "4231", "2413"]
     highlighted_nodes = highlighted_nodes
-    _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
-    _verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
-    _verify_render_type_of_nodes(tester, highlighted_nodes, render_type="highlighted")
+    verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
+    verify_render_type_of_nodes(tester, highlighted_nodes, render_type="highlighted")
 
     # selected/highlighted edges are part of the atg, other edges are "visual aids"
     some_selected_edges = [("2134", "2143"), ("1234", "1324"), ("3142", "3412")]
     some_other_edges = [("4321", "4231"), ("2143", "2413")]
     highlighted_edges = [("4123", "1423"), ("1423", "1243"), ("1243", "1234")]
     some_edges_that_dont_exist = [("1243", "3142"), ("4123", "4321"), ("1234", "2314")]
-    _verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
-    _verify_render_type_of_edges(tester, some_other_edges, render_type="other")
-    _verify_render_type_of_edges(tester, highlighted_edges, render_type="highlighted")
-    _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+    verify_render_type_of_edges(tester, some_selected_edges, render_type="selected")
+    verify_render_type_of_edges(tester, some_other_edges, render_type="other")
+    verify_render_type_of_edges(tester, highlighted_edges, render_type="highlighted")
+    verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
 
     # edges are colored according to swap type except highlighted edges
     edge_24 = [("3124", "3142"), ("1324", "1342")]
     edge_13 = [("3124", "1324"), ("3142", "1342")]
     edge_23 = [("1423", "1432"), ("1234", "1324")]
     diff_swap = [("2134", "2143"), ("1234", "2134")]
-    _verify_edges_have_the_same_color(tester, edge_24)
-    _verify_edges_have_the_same_color(tester, edge_13)
-    _verify_edges_have_the_same_color(tester, edge_23)
-    _verify_edges_have_different_colors(tester, *diff_swap)
+    verify_edges_have_the_same_color(tester, edge_24)
+    verify_edges_have_the_same_color(tester, edge_13)
+    verify_edges_have_the_same_color(tester, edge_23)
+    verify_edges_have_different_colors(tester, *diff_swap)

--- a/backend/tests/test_posetvisualizer.py
+++ b/backend/tests/test_posetvisualizer.py
@@ -40,7 +40,7 @@ Charateristics of Nodes and Edges according to Class
         Then other attributes can be check for their numerical value
 
 Proposed Test Organization
-1. test "default" output (i.e. without selection; permutahedron)
+1. test "default" output (i.e. without selection; permutahedron). effectively the same as .select_nodes(<all_nodes>)
     Call PosetVisualizer(n) for n = 3 to 5
     a. edges
     b. nodes
@@ -52,15 +52,135 @@ Proposed Test Organization
     Call PosetVisualizer(n) for n = 3 and 4, then call .select_and_highlight_nodes()
     a. edges
     b. nodes
+
+New Test Proposal
+Now, since it is clear we are operating with three render types, I suppose we should not test for the definition anymore.
+(Notice that the ATG in the paper does not deal with highlighted edges, nor "other" nodes.)
+Instead, we should simply test for the render types and hope that our representation still contains the ATG.
+1. test_errors_raised
+2. test "default" output (i.e. without selection; permutahedron). effectively the same as .select_nodes(<all_nodes>)
+    Call PosetVisualizer(n) for n = 3 and 4
+    a. nodes (selected)
+    b. edges (selected, does not exist)
+3. test select_nodes
+    Call PosetVisualizer(n) for n = 3 and 4, then call .select_nodes()
+    a. nodes (selected, other)
+    b. edges (selected, other, does not exist)
+4. test select_and_highlight_nodes()
+    Call PosetVisualizer(n) for n = 3 and 4, then call .select_and_highlight_nodes()
+    a. nodes (selected, highlighted, other)
+    b. edges (selected, highlighted, other, does not exist)
 """
 
 import pytest
 
-from app.posetvisualizer import PosetVisualizer
+from app.posetvisualizer import PosetVisualizer, RenderType
 from tests.testing_utils import FigureTester
 
+from .upsilon_constants import TWOMAXIMAL
 
-def testPosetVisualizer():
+RENDER_TYPE_SPECS = PosetVisualizer.RENDER_TYPE_SPECS
+
+
+def _verify_egdes_have_the_same_color(
+    tester: FigureTester, edges: list[tuple[str, str]]
+) -> bool:
+    """Verify edges provided all have the same color. Not applicable to lists containing highlighted edges.
+
+    Equivalent to verifying that all edges have the same swap, i.e. same equivalence class
+    """
+    edge0 = edges[0]
+    color0 = tester.get_edge_data(*edge0)["line"]["color"]
+    for edge in edges[1:]:
+        color = tester.get_edge_data(*edge)["line"]["color"]
+        if color != color0:
+            return False
+    return True
+
+
+def _verify_edges_do_not_exist(tester, edges) -> bool:
+    """Verify if all edges provided are NOT part of the atg
+
+    Edges which differ with more than one adjacent swap should not be part of the atg
+    """
+    for node_text1, node_text2 in edges:
+        edge_data = tester.get_edge_data(node_text1, node_text2)
+        if edge_data is not None:
+            return False  # f"edge provided '{(node_text1, node_text2)}', while expected to not exist, does exist in figure data"
+    return True
+
+
+def _verify_render_type_of_nodes(
+    tester: FigureTester, nodes: list[str], render_type: RenderType
+) -> bool:
+    render_type_color = RENDER_TYPE_SPECS["node"][render_type]["color"]
+    render_type_size = RENDER_TYPE_SPECS["node"][render_type]["size"]
+    render_type_opacity = RENDER_TYPE_SPECS["node"][render_type]["opacity"]
+    for node_text in nodes:
+        node_data = tester.get_node_data(node_text)
+        assert (
+            node_data
+        ), f"node '{node_text}', while expected to exist, does not exist in figure data"
+        color = node_data["marker"]["color"]
+        size = node_data["marker"]["size"]
+        opacity = node_data["opacity"]
+        if not all(
+            [
+                color == render_type_color,
+                size == render_type_size,
+                opacity == render_type_opacity,
+            ]
+        ):
+            return False
+    return True
+
+
+def _verify_render_type_of_edges(
+    tester: FigureTester, edges: list[tuple[str, str]], render_type: RenderType
+) -> bool:
+    highlighted_color = RENDER_TYPE_SPECS["edge"]["highlighted"]["color"]
+    render_type_width = RENDER_TYPE_SPECS["edge"][render_type]["width"]
+    render_type_opacity = RENDER_TYPE_SPECS["edge"][render_type]["opacity"]
+    for node_text1, node_text2 in edges:
+        edge_data = tester.get_edge_data(node_text1, node_text2)
+        assert (
+            edge_data
+        ), f"edge '{(node_text1, node_text2)}', while expected to exist, does not exist in figure data"
+        color = edge_data["line"]["color"]
+        width = edge_data["line"]["width"]
+        opacity = edge_data["opacity"]
+        if not all(
+            [
+                render_type != "highlighted" or color == highlighted_color,
+                width == render_type_width,
+                opacity == render_type_opacity,
+            ]
+        ):
+            return False
+    return True
+
+
+def _verify_nodes_are_highlighted(tester: FigureTester, nodes: list[str]) -> bool:
+    highlighted_color = RENDER_TYPE_SPECS["node"]["highlighted"]["color"]
+    highlighted_size = RENDER_TYPE_SPECS["node"]["highlighted"]["size"]
+    highlighted_opacity = RENDER_TYPE_SPECS["node"]["highlighted"]["opacity"]
+    for node_text in nodes:
+        node_data = tester.get_node_data(node_text)
+        color = node_data["marker"]["color"]
+        size = node_data["marker"]["size"]
+        opacity = node_data["opacity"]
+        if not all(
+            [
+                color == highlighted_color,
+                size == highlighted_size,
+                opacity == highlighted_opacity,
+            ]
+        ):
+            return False
+    return True
+
+
+def test_errors_raised():
     with pytest.raises(Exception, match="at least 2"):
         PosetVisualizer(1)
 
@@ -70,38 +190,220 @@ def testPosetVisualizer():
     with pytest.raises(TypeError, match="must be an integer"):
         PosetVisualizer("4")
 
+
+def test_default_behavior():
     # ============ Size 3 ============ #
     visualizer = PosetVisualizer(3)
     tester = FigureTester(visualizer.get_figure_data())
 
-    # Edges only exist between adjacent swaps
-    assert tester.get_edge_data("123", "132") != None
-    assert tester.get_edge_data("123", "321") == None
+    # selected/highlighted nodes are part of the atg
+    # for this case, there are no "highlighted", "other", and "does not exist" nodes to check
+    selected_nodes = ["123", "132", "213", "231", "312", "321"]
+    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
 
-    # Edges are colored according to swap type
-    assert (
-        tester.get_edge_data("123", "132")["line"]["color"]
-        == tester.get_edge_data("231", "321")["line"]["color"]
-    )
-    assert (
-        tester.get_edge_data("123", "132")["line"]["color"]
-        != tester.get_edge_data("123", "213")["line"]["color"]
-    )
+    # selected/highlighted edges are part of the atg, other edges are "visual aids"
+    # for this case, there are no "highlighted" and "other" edges to check
+    selected_edges = [("123", "132"), ("213", "231"), ("312", "321")]
+    some_edges_that_dont_exist = [
+        ("123", "312"),
+        ("123", "321"),
+        ("123", "231"),
+        ("312", "213"),
+    ]
+    assert _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+
+    # edges are colored according to swap type except highlighted edges
+    edge_12 = [("123", "213"), ("312", "321")]
+    edge_23 = [("123", "132"), ("231", "321")]
+    diff_swap = [("123", "132"), ("123", "213")]
+    assert _verify_egdes_have_the_same_color(tester, edge_23)
+    assert _verify_egdes_have_the_same_color(tester, edge_12)
+    assert not _verify_egdes_have_the_same_color(tester, diff_swap)
 
     # ============ Size 4 ============ #
     visualizer = PosetVisualizer(4)
     tester = FigureTester(visualizer.get_figure_data())
 
-    # Edges only exist between adjacent swaps
-    assert tester.get_edge_data("1234", "1324") != None
-    assert tester.get_edge_data("1234", "3214") == None
+    # selected/highlighted nodes are part of the atg
+    # for this case, there are no "highlighted", "other", and "does not exist" nodes to check
+    some_selected_nodes = ["1243", "1432", "2134", "2431", "4312", "3214"]
+    assert _verify_render_type_of_nodes(
+        tester, some_selected_nodes, render_type="selected"
+    )
 
-    # Edges are colored according to swap type
-    assert (
-        tester.get_edge_data("1234", "1324")["line"]["color"]
-        == tester.get_edge_data("4231", "4321")["line"]["color"]
+    # selected/highlighted edges are part of the atg, other edges are "visual aids"
+    # for this case, there are no "highlighted" and "other" edges to check
+    some_selected_edges = [("1423", "1432"), ("2134", "2143"), ("4312", "4321")]
+    some_edges_that_dont_exist = [
+        ("1234", "3124"),
+        ("1423", "3421"),
+        ("1243", "2341"),
+        ("4312", "4213"),
+    ]
+    assert _verify_render_type_of_edges(
+        tester, some_selected_edges, render_type="selected"
     )
-    assert (
-        tester.get_edge_data("1234", "1324")["line"]["color"]
-        != tester.get_edge_data("1234", "2134")["line"]["color"]
+    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+
+    # edges are colored according to swap type except highlighted edges
+    edge_14 = [("2143", "2413"), ("3214", "3241"), ("1423", "4123")]
+    edge_24 = [("1243", "1423"), ("2413", "4213"), ("1324", "1342")]
+    diff_swap = [("1243", "1423"), ("1423", "4123")]
+    assert _verify_egdes_have_the_same_color(tester, edge_14)
+    assert _verify_egdes_have_the_same_color(tester, edge_24)
+    assert not _verify_egdes_have_the_same_color(tester, diff_swap)
+
+
+def test_select_nodes():
+    # ============ Size 3 ============ #
+    visualizer = PosetVisualizer(3)
+    selected_nodes = ["123", "132", "312", "321"]
+    visualizer.select_nodes(selected_nodes)
+    tester = FigureTester(visualizer.get_figure_data())
+
+    # selected/highlighted nodes are part of the atg
+    # for this case, there are no "highlighted", and "does not exist" nodes to check
+    selected_nodes = selected_nodes
+    other_nodes = ["231", "213"]
+    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    assert _verify_render_type_of_nodes(tester, other_nodes, render_type="other")
+
+    # selected edges are part of the atg, other edges are "visual aids"
+    # for this case, there are no "highlighted" edges to check
+    selected_edges = [("123", "132"), ("132", "312"), ("312", "321")]
+    other_edges = [("321", "231"), ("231", "213"), ("213", "123")]
+    some_edges_that_dont_exist = [
+        ("123", "312"),
+        ("123", "321"),
+        ("123", "231"),
+        ("312", "213"),
+    ]
+    assert _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    assert _verify_render_type_of_edges(tester, other_edges, render_type="other")
+    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+
+    # edges are colored according to swap type except highlighted edges
+    # in this case, no "selected" edges have the same color
+    diff_swap1 = [("123", "132"), ("132", "312")]
+    diff_swap2 = [("123", "132"), ("312", "321")]
+    diff_swap3 = [("132", "312"), ("312", "321")]
+    assert not _verify_egdes_have_the_same_color(tester, diff_swap1)
+    assert not _verify_egdes_have_the_same_color(tester, diff_swap2)
+    assert not _verify_egdes_have_the_same_color(tester, diff_swap3)
+
+    # ============ Size 4 ============ #
+    visualizer = PosetVisualizer(4)
+    selected_nodes = TWOMAXIMAL
+    visualizer.select_nodes(selected_nodes)
+    tester = FigureTester(visualizer.get_figure_data())
+
+    # selected/highlighted nodes are part of the atg
+    # for this case, there are no "highlighted" and "does not exist" nodes to check
+    selected_nodes = selected_nodes
+    some_other_nodes = ["4321", "4231", "2413"]
+    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    assert _verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
+
+    # selected/highlighted edges are part of the atg, other edges are "visual aids"
+    # for this case, there are no "highlighted" edges to check
+    some_selected_edges = [("2134", "2143"), ("1234", "1324"), ("3142", "3412")]
+    some_other_edges = [("4321", "4231"), ("2143", "2413")]
+    some_edges_that_dont_exist = [("1243", "3142"), ("4123", "4321"), ("1234", "2314")]
+    assert _verify_render_type_of_edges(
+        tester, some_selected_edges, render_type="selected"
     )
+    assert _verify_render_type_of_edges(tester, some_other_edges, render_type="other")
+    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+
+    # edges are colored according to swap type except highlighted edges
+    edge_24 = [("3124", "3142"), ("1324", "1342"), ("1243", "1423")]
+    edge_13 = [("3124", "1324"), ("3142", "1342")]
+    edge_23 = [("1423", "1432"), ("1234", "1324")]
+    diff_swap = [("2134", "2143"), ("1234", "2134")]
+    assert _verify_egdes_have_the_same_color(tester, edge_24)
+    assert _verify_egdes_have_the_same_color(tester, edge_13)
+    assert _verify_egdes_have_the_same_color(tester, edge_23)
+    assert not _verify_egdes_have_the_same_color(tester, diff_swap)
+
+
+def test_select_and_highlight_nodes():
+    # ============ Size 3 ============ #
+    visualizer = PosetVisualizer(3)
+    selected_nodes = ["123", "132", "312", "321"]
+    highlighted_nodes = ["123", "132", "312"]
+    visualizer.select_and_highlight_nodes(selected_nodes, highlighted_nodes)
+    tester = FigureTester(visualizer.get_figure_data())
+
+    # selected/highlighted nodes are part of the atg
+    # for this case, there are no "does not exist" nodes to check
+    selected_nodes = ["321"]
+    other_nodes = ["231", "213"]
+    highlighted_nodes = highlighted_nodes
+    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    assert _verify_render_type_of_nodes(tester, other_nodes, render_type="other")
+    assert _verify_render_type_of_nodes(
+        tester, highlighted_nodes, render_type="highlighted"
+    )
+
+    # selected edges are part of the atg, other edges are "visual aids"
+    selected_edges = [("312", "321")]
+    other_edges = [("321", "231"), ("231", "213"), ("213", "123")]
+    highlighted_edges = [("132", "312"), ("123", "132")]
+    some_edges_that_dont_exist = [
+        ("123", "312"),
+        ("123", "321"),
+        ("123", "231"),
+        ("312", "213"),
+    ]
+    assert _verify_render_type_of_edges(tester, selected_edges, render_type="selected")
+    assert _verify_render_type_of_edges(tester, other_edges, render_type="other")
+    assert _verify_render_type_of_edges(
+        tester, highlighted_edges, render_type="highlighted"
+    )
+    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+
+    # edges are colored according to swap type except highlighted edges
+    # in this case, two out of three edges are highlighted, so nothing to test
+
+    # ============ Size 4 ============ #
+    visualizer = PosetVisualizer(4)
+    selected_nodes = TWOMAXIMAL
+    highlighted_nodes = ["4123", "1423", "1243", "1234"]
+    visualizer.select_and_highlight_nodes(selected_nodes, highlighted_nodes)
+    tester = FigureTester(visualizer.get_figure_data())
+
+    # selected/highlighted nodes are part of the atg
+    # for this case, there are no "does not exist" nodes to check
+    selected_nodes = list(set(TWOMAXIMAL) - set(highlighted_nodes))
+    some_other_nodes = ["4321", "4231", "2413"]
+    highlighted_nodes = highlighted_nodes
+    assert _verify_render_type_of_nodes(tester, selected_nodes, render_type="selected")
+    assert _verify_render_type_of_nodes(tester, some_other_nodes, render_type="other")
+    assert _verify_render_type_of_nodes(
+        tester, highlighted_nodes, render_type="highlighted"
+    )
+
+    # selected/highlighted edges are part of the atg, other edges are "visual aids"
+    some_selected_edges = [("2134", "2143"), ("1234", "1324"), ("3142", "3412")]
+    some_other_edges = [("4321", "4231"), ("2143", "2413")]
+    highlighted_edges = [("4123", "1423"), ("1423", "1243"), ("1243", "1234")]
+    some_edges_that_dont_exist = [("1243", "3142"), ("4123", "4321"), ("1234", "2314")]
+    assert _verify_render_type_of_edges(
+        tester, some_selected_edges, render_type="selected"
+    )
+    assert _verify_render_type_of_edges(tester, some_other_edges, render_type="other")
+    assert _verify_render_type_of_edges(
+        tester, highlighted_edges, render_type="highlighted"
+    )
+    assert _verify_edges_do_not_exist(tester, some_edges_that_dont_exist)
+
+    # edges are colored according to swap type except highlighted edges
+    edge_24 = [("3124", "3142"), ("1324", "1342")]
+    edge_13 = [("3124", "1324"), ("3142", "1342")]
+    edge_23 = [("1423", "1432"), ("1234", "1324")]
+    diff_swap = [("2134", "2143"), ("1234", "2134")]
+    assert _verify_egdes_have_the_same_color(tester, edge_24)
+    assert _verify_egdes_have_the_same_color(tester, edge_13)
+    assert _verify_egdes_have_the_same_color(tester, edge_23)
+    assert not _verify_egdes_have_the_same_color(tester, diff_swap)

--- a/backend/tests/test_posetvisualizer.py
+++ b/backend/tests/test_posetvisualizer.py
@@ -39,20 +39,6 @@ Charateristics of Nodes and Edges according to Class
         Except for the variable color (<swap_color>), colors red and black can be verified as literals "red" and "black"
         Then other attributes can be check for their numerical value
 
-Proposed Test Organization
-1. test "default" output (i.e. without selection; permutahedron). effectively the same as .select_nodes(<all_nodes>)
-    Call PosetVisualizer(n) for n = 3 to 5
-    a. edges
-    b. nodes
-2. test select_nodes
-    Call PosetVisualizer(n) for n = 3 and 4, then call .select_nodes()
-    a. edges
-    b. nodes
-3. test select_and_highlight_nodes()
-    Call PosetVisualizer(n) for n = 3 and 4, then call .select_and_highlight_nodes()
-    a. edges
-    b. nodes
-
 New Test Proposal
 Now, since it is clear we are operating with three render types, I suppose we should not test for the definition anymore.
 (Notice that the ATG in the paper does not deal with highlighted edges, nor "other" nodes.)
@@ -82,7 +68,7 @@ from .upsilon_constants import TWOMAXIMAL
 RENDER_TYPE_SPECS = PosetVisualizer.RENDER_TYPE_SPECS
 
 
-def _verify_egdes_have_the_same_color(
+def _verify_edges_have_the_same_color(
     tester: FigureTester, edges: list[tuple[str, str]]
 ) -> bool:
     """Verify edges provided all have the same color. Not applicable to lists containing highlighted edges.
@@ -160,26 +146,6 @@ def _verify_render_type_of_edges(
     return True
 
 
-def _verify_nodes_are_highlighted(tester: FigureTester, nodes: list[str]) -> bool:
-    highlighted_color = RENDER_TYPE_SPECS["node"]["highlighted"]["color"]
-    highlighted_size = RENDER_TYPE_SPECS["node"]["highlighted"]["size"]
-    highlighted_opacity = RENDER_TYPE_SPECS["node"]["highlighted"]["opacity"]
-    for node_text in nodes:
-        node_data = tester.get_node_data(node_text)
-        color = node_data["marker"]["color"]
-        size = node_data["marker"]["size"]
-        opacity = node_data["opacity"]
-        if not all(
-            [
-                color == highlighted_color,
-                size == highlighted_size,
-                opacity == highlighted_opacity,
-            ]
-        ):
-            return False
-    return True
-
-
 def test_errors_raised():
     with pytest.raises(Exception, match="at least 2"):
         PosetVisualizer(1)
@@ -217,9 +183,9 @@ def test_default_behavior():
     edge_12 = [("123", "213"), ("312", "321")]
     edge_23 = [("123", "132"), ("231", "321")]
     diff_swap = [("123", "132"), ("123", "213")]
-    assert _verify_egdes_have_the_same_color(tester, edge_23)
-    assert _verify_egdes_have_the_same_color(tester, edge_12)
-    assert not _verify_egdes_have_the_same_color(tester, diff_swap)
+    assert _verify_edges_have_the_same_color(tester, edge_23)
+    assert _verify_edges_have_the_same_color(tester, edge_12)
+    assert not _verify_edges_have_the_same_color(tester, diff_swap)
 
     # ============ Size 4 ============ #
     visualizer = PosetVisualizer(4)
@@ -250,9 +216,9 @@ def test_default_behavior():
     edge_14 = [("2143", "2413"), ("3214", "3241"), ("1423", "4123")]
     edge_24 = [("1243", "1423"), ("2413", "4213"), ("1324", "1342")]
     diff_swap = [("1243", "1423"), ("1423", "4123")]
-    assert _verify_egdes_have_the_same_color(tester, edge_14)
-    assert _verify_egdes_have_the_same_color(tester, edge_24)
-    assert not _verify_egdes_have_the_same_color(tester, diff_swap)
+    assert _verify_edges_have_the_same_color(tester, edge_14)
+    assert _verify_edges_have_the_same_color(tester, edge_24)
+    assert not _verify_edges_have_the_same_color(tester, diff_swap)
 
 
 def test_select_nodes():
@@ -288,9 +254,9 @@ def test_select_nodes():
     diff_swap1 = [("123", "132"), ("132", "312")]
     diff_swap2 = [("123", "132"), ("312", "321")]
     diff_swap3 = [("132", "312"), ("312", "321")]
-    assert not _verify_egdes_have_the_same_color(tester, diff_swap1)
-    assert not _verify_egdes_have_the_same_color(tester, diff_swap2)
-    assert not _verify_egdes_have_the_same_color(tester, diff_swap3)
+    assert not _verify_edges_have_the_same_color(tester, diff_swap1)
+    assert not _verify_edges_have_the_same_color(tester, diff_swap2)
+    assert not _verify_edges_have_the_same_color(tester, diff_swap3)
 
     # ============ Size 4 ============ #
     visualizer = PosetVisualizer(4)
@@ -321,10 +287,10 @@ def test_select_nodes():
     edge_13 = [("3124", "1324"), ("3142", "1342")]
     edge_23 = [("1423", "1432"), ("1234", "1324")]
     diff_swap = [("2134", "2143"), ("1234", "2134")]
-    assert _verify_egdes_have_the_same_color(tester, edge_24)
-    assert _verify_egdes_have_the_same_color(tester, edge_13)
-    assert _verify_egdes_have_the_same_color(tester, edge_23)
-    assert not _verify_egdes_have_the_same_color(tester, diff_swap)
+    assert _verify_edges_have_the_same_color(tester, edge_24)
+    assert _verify_edges_have_the_same_color(tester, edge_13)
+    assert _verify_edges_have_the_same_color(tester, edge_23)
+    assert not _verify_edges_have_the_same_color(tester, diff_swap)
 
 
 def test_select_and_highlight_nodes():
@@ -403,7 +369,7 @@ def test_select_and_highlight_nodes():
     edge_13 = [("3124", "1324"), ("3142", "1342")]
     edge_23 = [("1423", "1432"), ("1234", "1324")]
     diff_swap = [("2134", "2143"), ("1234", "2134")]
-    assert _verify_egdes_have_the_same_color(tester, edge_24)
-    assert _verify_egdes_have_the_same_color(tester, edge_13)
-    assert _verify_egdes_have_the_same_color(tester, edge_23)
-    assert not _verify_egdes_have_the_same_color(tester, diff_swap)
+    assert _verify_edges_have_the_same_color(tester, edge_24)
+    assert _verify_edges_have_the_same_color(tester, edge_13)
+    assert _verify_edges_have_the_same_color(tester, edge_23)
+    assert not _verify_edges_have_the_same_color(tester, diff_swap)

--- a/backend/tests/testing_utils.py
+++ b/backend/tests/testing_utils.py
@@ -17,24 +17,26 @@ class FigureTester:
 
         for trace in self._data:
             is_node_trace = "markers" in trace.get("mode", "")
+            if not is_node_trace:
+                continue
 
-            if is_node_trace:
-                for i, node_text in enumerate(trace["text"]):
-                    if str(node_text) == text:
-                        return NodeData(
-                            hoverinfo=trace["hoverinfo"],
-                            marker=trace["marker"],
-                            mode=trace["mode"],
-                            name=trace["name"],
-                            opacity=trace["opacity"],
-                            showlegend=trace["showlegend"],
-                            text=trace["text"][i],
-                            textposition=trace["textposition"],
-                            x=trace["x"][i],
-                            y=trace["y"][i],
-                            z=trace["z"][i],
-                        )
+            for i, node_text in enumerate(trace["text"]):
+                if str(node_text) != text:
+                    continue
 
+                return NodeData(
+                    hoverinfo=trace["hoverinfo"],
+                    marker=trace["marker"],
+                    mode=trace["mode"],
+                    name=trace["name"],
+                    opacity=trace["opacity"],
+                    showlegend=trace["showlegend"],
+                    text=trace["text"][i],
+                    textposition=trace["textposition"],
+                    x=trace["x"][i],
+                    y=trace["y"][i],
+                    z=trace["z"][i],
+                )
         return None
 
     def get_edge_data(self, n1: str, n2: str) -> EdgeData | None:
@@ -42,35 +44,35 @@ class FigureTester:
 
         for trace in self._data:
             is_edge_trace = "lines" in trace.get("mode", "")
+            if not is_edge_trace:
+                continue
 
-            if is_edge_trace:
-                for i in range(0, len(trace["x"]), 3):
-                    start_node = self.get_node_data_by_position(
-                        trace["x"][i], trace["y"][i], trace["z"][i]
-                    )
-                    end_node = self.get_node_data_by_position(
-                        trace["x"][i + 1], trace["y"][i + 1], trace["z"][i + 1]
-                    )
+            for i in range(0, len(trace["x"]), 3):
+                start_node = self.get_node_data_by_position(
+                    trace["x"][i], trace["y"][i], trace["z"][i]
+                )
+                end_node = self.get_node_data_by_position(
+                    trace["x"][i + 1], trace["y"][i + 1], trace["z"][i + 1]
+                )
 
-                    if (
-                        start_node
-                        and end_node
-                        and (
-                            (start_node["text"] == n1 and end_node["text"] == n2)
-                            or (start_node["text"] == n2 and end_node["text"] == n1)
-                        )
-                    ):
-                        return EdgeData(
-                            hoverinfo=trace["hoverinfo"],
-                            line=trace["line"],
-                            mode=trace["mode"],
-                            name=trace["name"],
-                            opacity=trace["opacity"],
-                            showlegend=trace["showlegend"],
-                            x=(trace["x"][i], trace["x"][i + 1]),
-                            y=(trace["y"][i], trace["x"][i + 1]),
-                            z=(trace["z"][i], trace["x"][i + 1]),
-                        )
+                if not start_node or not end_node:
+                    continue
+                if not (start_node["text"] == n1 and end_node["text"] == n2) and not (
+                    start_node["text"] == n2 and end_node["text"] == n1
+                ):
+                    continue
+
+                return EdgeData(
+                    hoverinfo=trace["hoverinfo"],
+                    line=trace["line"],
+                    mode=trace["mode"],
+                    name=trace["name"],
+                    opacity=trace["opacity"],
+                    showlegend=trace["showlegend"],
+                    x=(trace["x"][i], trace["x"][i + 1]),
+                    y=(trace["y"][i], trace["x"][i + 1]),
+                    z=(trace["z"][i], trace["x"][i + 1]),
+                )
         return None
 
     def get_node_data_by_position(
@@ -80,21 +82,24 @@ class FigureTester:
 
         for trace in self._data:
             is_node_trace = "markers" in trace.get("mode", "")
+            if not is_node_trace:
+                continue
 
-            if is_node_trace:
-                for i in range(len(trace["text"])):
-                    if (trace["x"][i], trace["y"][i], trace["z"][i]) == (x, y, z):
-                        return NodeData(
-                            hoverinfo=trace["hoverinfo"],
-                            marker=trace["marker"],
-                            mode=trace["mode"],
-                            name=trace["name"],
-                            opacity=trace["opacity"],
-                            showlegend=trace["showlegend"],
-                            text=trace["text"][i],
-                            textposition=trace["textposition"],
-                            x=trace["x"][i],
-                            y=trace["y"][i],
-                            z=trace["z"][i],
-                        )
+            for i in range(len(trace["text"])):
+                if (trace["x"][i], trace["y"][i], trace["z"][i]) != (x, y, z):
+                    continue
+
+                return NodeData(
+                    hoverinfo=trace["hoverinfo"],
+                    marker=trace["marker"],
+                    mode=trace["mode"],
+                    name=trace["name"],
+                    opacity=trace["opacity"],
+                    showlegend=trace["showlegend"],
+                    text=trace["text"][i],
+                    textposition=trace["textposition"],
+                    x=trace["x"][i],
+                    y=trace["y"][i],
+                    z=trace["z"][i],
+                )
         return None


### PR DESCRIPTION
- create RENDER_TYPE_SPECIFICATIONS
- small changes to FigureTester
- create tests for the functions PosetVisualizer(), .select_nodes, and .select_and_highlight_nodes

TODO:
- either move the assertions to the "underscore" functions or make them return a reason for test failure