### PR TITLE
modify graph from cover relation endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -74,21 +74,22 @@ def get_graph(
 
 
 @app.get("/graph_from_cover_relation", response_model=GraphData)
-def get_posetgraph(permutation_length: int, cover_relation: list[list[int]]):
+def get_posetgraph(permutation_length: int, flattened_relation: list[int] = Query(...)):
     try:
         if permutation_length < 2 or permutation_length > PosetVisualizer.MAX_SIZE:
             raise ValueError(
                 f"Permutation length must be between 2 and {PosetVisualizer.MAX_SIZE}."
             )
 
-        cover_relation1: CoverRelation = [
-            (relation[0], relation[1]) for relation in cover_relation
+        cover_relation: CoverRelation = [
+            (flattened_relation[i], flattened_relation[i + 1])
+            for i in range(0, len(flattened_relation), 2)
         ]
 
         visualizer = PosetVisualizer(permutation_length)
         sequence: str = "".join(map(str, range(1, permutation_length + 1)))
         linear_extensions: LinearExtensions = (
-            PosetUtils.get_linear_extensions_from_relation(cover_relation1, sequence)
+            PosetUtils.get_linear_extensions_from_relation(cover_relation, sequence)
         )
         visualizer.select_nodes(linear_extensions)
 


### PR DESCRIPTION
expect flattened cover relation and simply rebuild the cover relation in the endpoint function

cover relation is of the form list[tuple[int,int]]
however, due to the limitations of 'vanilla' fastapi, nested structures cannot be passed in GET requests
so, I opted to expect a flattened list and simply pair up the numbers to build the cover relation